### PR TITLE
never not build

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,25 +50,25 @@
 //!     .expect("Failed to render DLSS");
 //! ```
 
-#[cfg(not(feature = "mock"))]
+#[cfg(not(dlss = "mock"))]
 mod feature_info;
-#[cfg(not(feature = "mock"))]
+#[cfg(not(dlss = "mock"))]
 mod initialization;
-#[cfg(not(feature = "mock"))]
+#[cfg(not(dlss = "mock"))]
 mod nvsdk_ngx;
-#[cfg(not(feature = "mock"))]
+#[cfg(not(dlss = "mock"))]
 mod sdk;
 
 /// DLSS Ray Reconstruction.
-#[cfg(not(feature = "mock"))]
+#[cfg(not(dlss = "mock"))]
 pub mod ray_reconstruction;
 /// DLSS Super Resolution.
-#[cfg(not(feature = "mock"))]
+#[cfg(not(dlss = "mock"))]
 pub mod super_resolution;
 
-#[cfg(not(feature = "mock"))]
+#[cfg(not(dlss = "mock"))]
 pub use initialization::{FeatureSupport, InitializationError, create_instance, request_device};
-#[cfg(not(feature = "mock"))]
+#[cfg(not(dlss = "mock"))]
 pub use nvsdk_ngx::{DlssError, DlssFeatureFlags, DlssPerfQualityMode};
-#[cfg(not(feature = "mock"))]
+#[cfg(not(dlss = "mock"))]
 pub use sdk::DlssSdk;


### PR DESCRIPTION
**note that I'm not sure this is a good idea, but this is an alternative to a mock feature**

This change the build script to never fail the build, but automatically build in mock mode when an SDK is not available.

It would move the responsibility to detect platform support to the dependents