### PR TITLE
Bugfixes, version bump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dlss_wgpu"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2024"
 categories = ["graphics", "rendering"]
 description = "Adds support for using DLSS with wgpu"

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ The DLSS SDK cannot be redistributed by this crate. You will need to download th
 ## Distributing Your App
 Once your app is compiled, you do not need to distribute the entire DLSS SDK, or set the `DLSS_SDK` environment variable. You only need to distribute the DLSS DLL(s) and license text as follows:
 
-* For DLSS super resolution:
-    * Window: Copy `$DLSS_SDK/lib/Windows_x86_64/rel/nvngx_dlss.dll` to the same directory as your app
+1. Copy the DLL:
+    * Windows: Copy `$DLSS_SDK/lib/Windows_x86_64/rel/nvngx_dlss.dll` to the same directory as your app
     * Linux: Copy `$DLSS_SDK/lib/Linux_x86_64/rel/libnvidia-ngx-dlss.so.310.4.0` to the same directory as your app
-* For DLSS ray reconstruction:
+2. Include the full copyright and license blurb texts from section `9.5` of `$DLSS_SDK/doc/DLSS_Programming_Guide_Release.pdf` with your app
+3. Additionally, for DLSS ray reconstruction:
     * Windows: Copy `$DLSS_SDK/lib/Windows_x86_64/rel/nvngx_dlssd.dll` to the same directory as your app
     * Linux: Copy `$DLSS_SDK/lib/Linux_x86_64/rel/libnvidia-ngx-dlssd.so.310.4.0` to the same directory as your app
-* Include the full copyright and license blurb texts from section `9.5` of `$DLSS_SDK/doc/DLSS_Programming_Guide_Release.pdf` with your app
 
 ## Debug Overlay
 When `dlss_wgpu` is compiled with the `debug_overlay` cargo feature, and the `DLSS_SDK` environment variable is set, the development version of the DLSS DLLs will be linked.

--- a/README.md
+++ b/README.md
@@ -5,14 +5,15 @@ A wrapper for using [DLSS](https://www.nvidia.com/en-us/geforce/technologies/dls
 
 ## Version Chart
 
-| dlss_wgpu |   dlss   | wgpu |
-|:---------:|:--------:|:----:|
-|    v1.0   | v310.3.0 |  v26 |
+|  dlss_wgpu  |   dlss   | wgpu |
+|:-----------:|:--------:|:----:|
+|    v1.0.1   | v310.4.0 |  v26 |
+|    v1.0.0   | v310.3.0 |  v26 |
 
 ## Downloading The DLSS SDK
 The DLSS SDK cannot be redistributed by this crate. You will need to download the SDK as follows:
-* Ensure you comply with the DLSS SDK license located at https://github.com/NVIDIA/DLSS/blob/v310.3.0/LICENSE.txt
-* Clone the NVIDIA DLSS Super Resolution SDK v310.3.0 from https://github.com/NVIDIA/DLSS/tree/v310.3.0
+* Ensure you comply with the DLSS SDK license located at https://github.com/NVIDIA/DLSS/blob/v310.4.0/LICENSE.txt
+* Clone the NVIDIA DLSS Super Resolution SDK v310.4.0 from https://github.com/NVIDIA/DLSS/tree/v310.4.0
 * Set the environment variable `DLSS_SDK = /path/to/DLSS`
 
 ## Build Dependencies
@@ -25,10 +26,10 @@ Once your app is compiled, you do not need to distribute the entire DLSS SDK, or
 
 * For DLSS super resolution:
     * Window: Copy `$DLSS_SDK/lib/Windows_x86_64/rel/nvngx_dlss.dll` to the same directory as your app
-    * Linux: Copy `$DLSS_SDK/lib/Linux_x86_64/rel/libnvidia-ngx-dlss.so.310.3.0` to the same directory as your app
+    * Linux: Copy `$DLSS_SDK/lib/Linux_x86_64/rel/libnvidia-ngx-dlss.so.310.4.0` to the same directory as your app
 * For DLSS ray reconstruction:
     * Windows: Copy `$DLSS_SDK/lib/Windows_x86_64/rel/nvngx_dlssd.dll` to the same directory as your app
-    * Linux: Copy `$DLSS_SDK/lib/Linux_x86_64/rel/libnvidia-ngx-dlssd.so.310.3.0` to the same directory as your app
+    * Linux: Copy `$DLSS_SDK/lib/Linux_x86_64/rel/libnvidia-ngx-dlssd.so.310.4.0` to the same directory as your app
 * Include the full copyright and license blurb texts from section `9.5` of `$DLSS_SDK/doc/DLSS_Programming_Guide_Release.pdf` with your app
 
 ## Debug Overlay

--- a/src/feature_info.rs
+++ b/src/feature_info.rs
@@ -1,6 +1,6 @@
 use crate::nvsdk_ngx::*;
 use std::{
-    env::{self, var},
+    env::{self, current_dir, var},
     ffi::{CString, OsStr, OsString},
     ptr,
 };
@@ -55,8 +55,12 @@ where
 }
 
 fn get_shared_library_paths() -> Vec<Vec<wchar_t>> {
+    let mut shared_library_paths = vec![];
+
     // Look in current direction
-    let mut shared_library_paths = vec![os_str_to_wchar(&OsString::from("."))];
+    if let Ok(current_directory) = current_dir() {
+        shared_library_paths.push(os_str_to_wchar(current_directory.as_os_str()));
+    }
 
     #[cfg(not(target_os = "windows"))]
     let platform = "Linux_x86_64";

--- a/src/feature_info.rs
+++ b/src/feature_info.rs
@@ -1,6 +1,6 @@
 use crate::nvsdk_ngx::*;
 use std::{
-    env,
+    env::{self, var},
     ffi::{CString, OsStr, OsString},
     ptr,
 };
@@ -69,8 +69,8 @@ fn get_shared_library_paths() -> Vec<Vec<wchar_t>> {
     let profile = "rel";
 
     // Look in $DLSS_SDK if set
-    let sdk_path = option_env!("DLSS_SDK").map(|sdk| format!("{sdk}/lib/{platform}/{profile}"));
-    if let Some(sdk_path) = sdk_path.as_ref() {
+    let sdk_path = var("DLSS_SDK").map(|sdk| format!("{sdk}/lib/{platform}/{profile}"));
+    if let Ok(sdk_path) = sdk_path.as_ref() {
         shared_library_paths.push(os_str_to_wchar(&OsString::from(sdk_path)));
     }
 

--- a/src/feature_info.rs
+++ b/src/feature_info.rs
@@ -1,6 +1,6 @@
 use crate::nvsdk_ngx::*;
 use std::{
-    env::{self, current_dir, var},
+    env::{self, current_exe, var},
     ffi::{CString, OsStr, OsString},
     ptr,
 };
@@ -58,7 +58,8 @@ fn get_shared_library_paths() -> Vec<Vec<wchar_t>> {
     let mut shared_library_paths = vec![];
 
     // Look in current direction
-    if let Ok(current_directory) = current_dir() {
+    if let Ok(binary_path) = current_exe() {
+        let current_directory = binary_path.parent().unwrap();
         shared_library_paths.push(os_str_to_wchar(current_directory.as_os_str()));
     }
 

--- a/src/feature_info.rs
+++ b/src/feature_info.rs
@@ -1,6 +1,6 @@
 use crate::nvsdk_ngx::*;
 use std::{
-    env::{self, current_exe, var},
+    env::{self, var},
     ffi::{CString, OsStr, OsString},
     ptr,
 };
@@ -56,12 +56,6 @@ where
 
 fn get_shared_library_paths() -> Vec<Vec<wchar_t>> {
     let mut shared_library_paths = vec![];
-
-    // Look in current direction
-    if let Ok(binary_path) = current_exe() {
-        let current_directory = binary_path.parent().unwrap();
-        shared_library_paths.push(os_str_to_wchar(current_directory.as_os_str()));
-    }
 
     #[cfg(not(target_os = "windows"))]
     let platform = "Linux_x86_64";


### PR DESCRIPTION
Fixes https://github.com/bevyengine/dlss_wgpu/issues/10.

* When finding DLSS DLLs, lookup $DLSS_SDK at runtime instead of baking the path in at compile time
* Remove current directory lookup for DLLs, as DLSS already does that implicitly
* Fix README instructions to mention that you need both the DLSS and DLSS-RR DLLs when using DLSS-RR
* Bump DLSS SDK and crate minor version 